### PR TITLE
Catch the install to cargo/bin on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
             const pathsToCheck = [
                 // cargo install location
                 '~/.cargo/bin/nu',
+                '~/.cargo/bin/nu.exe',
 
                 // winget on Windows install location
                 'c:\\program files\\nu\\bin\\nu.exe',


### PR DESCRIPTION
The path lookup doesn't respect PATHEXT so `nu` doesn't find `nu.exe`