### PR TITLE
fix `use` when it's used in variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,3 +125,4 @@ All notable changes to the "vscode-nushell-lang" extension will be documented in
 
 - 1.2.0
   - No longer a preview release
+  - Fix `use` coloring when used in variable naming

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -427,7 +427,7 @@
                     ]
                 },
                 {
-                    "match": "^\\s*(?:export )?use",
+                    "match": "^\\s*(?:export )?use\\b",
                     "captures": {
                         "0": { "name": "entity.name.function.nushell" }
                     }


### PR DESCRIPTION
Fixes a small bug where `use` was highlighted incorrectly after #79. Thanks @glcraft for your help!
