### PR TITLE
change include dir separator from semicolon to colon

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -383,7 +383,7 @@ async function runCompiler(
   let stdout = "";
   try {
     const script_path_flag =
-      includeFlagForPath(uri) + ";" + settings.includeDirs.join(";") + '"';
+      includeFlagForPath(uri) + ":" + settings.includeDirs.join(":") + '"';
 
     connection.console.log(
       "running: " +


### PR DESCRIPTION
This PR changes the include dir separator from a semicolon to a colon. It seems that nushell has difficulty parsing strings with semicolons so this is just an easier way to do it.