### PR TITLE
update vscode launch json so we can see debug messages from client

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,6 @@
       "name": "Launch Client",
       "runtimeExecutable": "${execPath}",
       "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-      "outFiles": ["${workspaceRoot}/client/out/**/*.js"],
       "preLaunchTask": {
         "type": "npm",
         "script": "compile"
@@ -23,8 +22,7 @@
         "--extensionDevelopmentPath=${workspaceRoot}",
         "--extensionTestsPath=${workspaceRoot}/client/out/test/index",
         "${workspaceRoot}/client/testFixture"
-      ],
-      "outFiles": ["${workspaceRoot}/client/out/test/**/*.js"]
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR removes the `outFiles` node in the launch configuration because it was preventing me from doing client side logging.