### PR TITLE
add a throttle timeout so that we don't update to frequently

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -202,14 +202,14 @@ documents.onDidClose((e) => {
   documentSettings.delete(e.document.uri);
 });
 
-function debounce(func, wait, immediate) {
-  let timeout;
+function debounce(func: any, wait: number, immediate: boolean) {
+  let timeout: any;
 
-  return function executedFunction(this: any) {
+  return function executedFunction(this: any, ...args: any[]) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const context = this;
     // eslint-disable-next-line prefer-rest-params
-    const args = arguments;
+    // const args = arguments;
 
     const later = function () {
       timeout = null;
@@ -233,6 +233,7 @@ documents.onDidChangeContent(
       500,
       false
     );
+
     return (change) => {
       throttledValidateTextDocument(change.document);
     };

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -205,8 +205,10 @@ documents.onDidClose((e) => {
 function debounce(func, wait, immediate) {
   let timeout;
 
-  return function executedFunction() {
+  return function executedFunction(this: any) {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     const context = this;
+    // eslint-disable-next-line prefer-rest-params
     const args = arguments;
 
     const later = function () {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -57,8 +57,6 @@ let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
 let hasDiagnosticRelatedInformationCapability = false;
 
-// let timerId: NodeJS.Timeout | undefined = undefined;
-
 function includeFlagForPath(file_path: string): string {
   if (file_path.startsWith("file://")) {
     file_path = decodeURI(file_path);
@@ -208,8 +206,6 @@ function debounce(func: any, wait: number, immediate: boolean) {
   return function executedFunction(this: any, ...args: any[]) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const context = this;
-    // eslint-disable-next-line prefer-rest-params
-    // const args = arguments;
 
     const later = function () {
       timeout = null;
@@ -217,11 +213,8 @@ function debounce(func: any, wait: number, immediate: boolean) {
     };
 
     const callNow = immediate && !timeout;
-
     clearTimeout(timeout);
-
     timeout = setTimeout(later, wait);
-
     if (callNow) func.apply(context, args);
   };
 }
@@ -253,12 +246,11 @@ async function validateTextDocument(
         return;
       }
 
-      // // In this simple example we get the settings for every validate run.
+      // In this simple example we get the settings for every validate run.
       const settings = await getDocumentSettings(textDocument.uri);
 
       // The validator creates diagnostics for all uppercase words length 2 and more
       const text = textDocument.getText();
-
       const lineBreaks = findLineBreaks(text);
 
       const stdout = await runCompiler(
@@ -269,7 +261,6 @@ async function validateTextDocument(
       );
 
       textDocument.nuInlayHints = [];
-
       const diagnostics: Diagnostic[] = [];
 
       // FIXME: We use this to deduplicate type hints given by the compiler.
@@ -425,10 +416,6 @@ async function runCompiler(
     const max_errors = settings.maxNumberOfProblems;
 
     if (flags.includes("ide-check")) {
-      // console.log(
-      //   "flags: [" + flags + "] [" + max_errors + "] uri: [" + uri + "]"
-      // );
-
       flags = flags + " " + max_errors;
     }
 
@@ -613,7 +600,6 @@ async function goToDefinition(
         ? (await fs.promises.readFile(obj.file)).toString()
         : document.getText() ?? ""
     );
-    // const uri = obj.file ? "file://" + obj.file : document.uri;
 
     let uri = "";
     if (obj.file == tmpFile.name) {


### PR DESCRIPTION
This PR adds a throttle to how often the document validation happens. 

I discovered we needed something like this while I was doing some script programming and watching the logs. I was adding comments to variables and custom commands when I noticed that on every single character that I typed, we called out to nushell to revalidate the document.

I found the main throttle function in jakt's extension but adjusted the timeout to 1500. I'm not sure 1500 is correct. The idea is only to update after a certain duration versus every character. We'll have to tune this over time.