### PR TITLE
Add underscore separator in numbers

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -151,7 +151,7 @@
             "name": "constant.numeric.nushell"
         },
         "numbers": {
-            "match": "(?<![\\w-])[-+]?\\d+(?:\\.\\d*)?(?i:ns|us|ms|sec|min|hr|day|wk|b|kb|mb|gb|tb|pt|eb|zb|kib|mib|gib|tib|pit|eib|zib)?(?:(?![\\w.])|(?=\\.\\.))",
+            "match": "(?<![\\w-])[-+]?(?:\\d+|\\d{1,3}(?:_\\d{3})*)(?:\\.\\d*)?(?i:ns|us|ms|sec|min|hr|day|wk|b|kb|mb|gb|tb|pt|eb|zb|kib|mib|gib|tib|pit|eib|zib)?(?:(?![\\w.])|(?=\\.\\.))",
             "name": "constant.numeric.nushell"
         },
         "binary": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6421451/232777368-0310417b-e4f2-47cd-9565-5b33de1d359e.png)

I changed number parsing to make underscore separator works. 

If the parsing is wrong, the number is not parsed as a number and by default, the extension goes for a bare string (as you can see on the screen).

closes #76