### PR TITLE
add folding regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,3 +133,4 @@ All notable changes to the "vscode-nushell-lang" extension will be documented in
   - Error squigglys
   - Auto-complete
   - Editor IDE Settings to help configure some features
+  - Added folding regions with `# region:` and `# endregion`

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -11,6 +11,11 @@
     ["[", "]"],
     ["(", ")"]
   ],
+  "colorizedBracketPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
   // symbols that are auto closed when typing
   "autoClosingPairs": [
     { "open": "{", "close": "}" },
@@ -32,8 +37,8 @@
   ],
   "folding": {
     "markers": {
-      "start": "^def\\b",
-      "end": "^\\}"
+      "start": "^\\s*# region:",
+      "end": "^\\s*# endregion"
     }
   },
   "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)",


### PR DESCRIPTION
This PR adds folding regions so that you can fold your code as you want it.

By adding `# region:` and `# endregion` around the code you want to fold, you can go from this.
![image](https://user-images.githubusercontent.com/343840/233646879-19b46a0e-69a3-4407-8528-445aaa6a0d52.png)
To this.
![image](https://user-images.githubusercontent.com/343840/233646945-f5f8157e-0727-4991-b9e8-d4827310fe59.png)
