### PR TITLE
change the `:` separator to a record separator `\x1e`

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -412,7 +412,11 @@ async function runCompiler(
   let stdout = "";
   try {
     const script_path_flag =
-      includeFlagForPath(uri) + ":" + settings.includeDirs.join(":") + '"';
+      includeFlagForPath(uri) +
+      "\x1e" + // \x1e is the record separator character (a character that is unlikely to appear in a path)
+      settings.includeDirs.join("\x1e") +
+      '"';
+
     const max_errors = settings.maxNumberOfProblems;
 
     if (flags.includes("ide-check")) {


### PR DESCRIPTION
This changes how the include paths are joined together so that it uses a character that will work across platforms. `;` didn't work on Mac/Linux. `:` didn't work in Windows. So, the `record separator` should work, which is `\x1e`.

This goes hand-in-hand with https://github.com/nushell/nushell/pull/8961