### PR TITLE
Fix datetime parsing

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -177,9 +177,9 @@
     "constant-value": {
       "patterns": [
         { "include": "#constant-keywords" },
+        { "include": "#datetime" },
         { "include": "#numbers" },
         { "include": "#numbers-hexa" },
-        { "include": "#datetime" },
         { "include": "#binary" }
       ]
     },

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -144,7 +144,7 @@
       "name": "variable.language.nushell"
     },
     "datetime": {
-      "match": "\\b\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?(?:\\+\\d{2}:?\\d{2}|Z)?)?\\b",
+      "match": "\\b\\d{4}-\\d{2}-\\d{2}(?:T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:\\+\\d{2}:?\\d{2}|Z)?)?\\b",
       "name": "constant.numeric.nushell"
     },
     "numbers-hexa": {


### PR DESCRIPTION
From https://github.com/nushell/vscode-nushell-lang/issues/139

* floating point seconds can have one or more digits (instead of up to 3)
* datetime rule is prioritized over numbers rule, so that the year is not parsed as number first instead of a full date.

<img width="533" alt="image" src="https://github.com/nushell/vscode-nushell-lang/assets/6421451/dcff1549-7c14-4a3e-a8ce-386de929d431">
