### PR TITLE
fix shebang/firstLine detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
           "light": "assets/nu.svg",
           "dark": "assets/nu.svg"
         },
+        "firstLine": "^#!\\s*/?.*\\bnu\\b",
         "configuration": "./language-configuration.json"
       }
     ],


### PR DESCRIPTION
Allow for detection of scripts without extension by using the first line detection, aka shebang.

Shamelessly copied from the python extension.

https://github.com/microsoft/vscode/blob/3519b130fbbd41281980d726dae3ca964305b329/extensions/python/package.json#L34
