### PR TITLE
automatically publish extension to open vsx registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,22 +44,18 @@ jobs:
         uses: myrotvorets/info-from-package-json-action@1.1.0
         id: ver
 
-      - uses: lannonbr/vsce-action@master
-        with:
-          args: "package"
-
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v1
+        id: publishOpenVSX
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          extensionFile: ./vscode-nushell-lang-${{ steps.ver.outputs.packageVersion }}.vsix
 
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ./vscode-nushell-lang-${{ steps.ver.outputs.packageVersion }}.vsix
+          extensionFile: ${{ steps.publishOpenVSX.outputs.vsixPath }}
           
       - name: Create Release
         id: create_release
@@ -79,6 +75,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./vscode-nushell-lang-${{ steps.ver.outputs.packageVersion }}.vsix # Need to get this version number dynamically
+          asset_path: ${{ steps.publishOpenVSX.outputs.vsixPath }} # Need to get this version number dynamically
           asset_name: vscode-nushell-lang-${{ steps.ver.outputs.packageVersion }}.vsix
           asset_content_type: application/vsix


### PR DESCRIPTION
Currently the release workflow just bundles the extension and uploads it to the newest Github Release, and then i assume the maintainers manually publish it to vscode marketplace. This pr attempts to publish the extension to the [open vsx registry](https://open-vsx.org/) by using the [HaaLeo/publish-vscode-extension](https://github.com/HaaLeo/publish-vscode-extension) action. By adding it to open vsx, stuff like [gitpod](https://gitpod.io) and [vscodium](https://vscodium.com/) and other tools which uses open vsx can also allow users to use the nushell extension. In #43 @fdncred mentioned that he couldn't get the action setup to automatically publish to the vscode marketplace. The action used for uploading to vsx can also do the same for vscode marketplace. I can push another commit if that is needed.

This will require a new secret named `OPEN_VSX_TOKEN` to be defined containing the access token for open vsx [more here](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#1-create-an-access-token) and a namespace created beforehand [more here](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#4-create-the-namespace)

This pr should resolve #43 