### PR TITLE
Syntax highlight: add "export" to "module"

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -332,7 +332,7 @@
       "patterns": [{ "include": "#function-parameters" }]
     },
     "module": {
-      "begin": "(module)\\s+([\\w\\-]+)\\s*\\{",
+      "begin": "((?:export\\s+)?module)\\s+([\\w\\-]+)\\s*\\{",
       "beginCaptures": {
         "1": { "name": "entity.name.function.nushell" },
         "2": { "name": "entity.name.namespace.nushell" }


### PR DESCRIPTION
A little fix which fix color of "export module"

Before:
<img width="347" alt="image" src="https://github.com/nushell/vscode-nushell-lang/assets/6421451/344128aa-267f-405f-bb98-25705b620482">

After:
<img width="350" alt="image" src="https://github.com/nushell/vscode-nushell-lang/assets/6421451/c32582cf-2434-48fd-b2fe-f57358de604c">
