### PR TITLE
Textmate: improvement on record entries and closure

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -526,17 +526,45 @@
       "name": "meta.expression.braced.nushell",
       "patterns": [
         {
-          "begin": "((?:(?:[^$\\(\\{\\[\"'#\\s][^\\(\\{\\[\"'#\\s]*)|\\$?(?:\"[^\"]+\"|'[^']+')))\\s*(:)\\s*",
-          "beginCaptures": {
-            "1": {
-              "name": "variable.other.nushell",
-              "patterns": [{ "include": "#paren-expression" }]
-            },
-            "2": { "patterns": [{ "include": "#operators" }] }
+          "match": "(\\w+)\\s*(:)\\s*",
+          "captures": {
+            "1": { "name": "variable.other.nushell" },
+            "2": { "name": "keyword.control.nushell" }
+          }
+        },
+        {
+          "match": "(\\$\"((?:[^\"\\\\]|\\\\.)*)\")\\s*(:)\\s*",
+          "captures": {
+            "1": { "name": "variable.other.nushell" },
+            "2": { "name": "variable.other.nushell", "patterns": [{ "include": "#paren-expression" }] },
+            "3": { "name": "keyword.control.nushell" }
           },
-          "end": "(?=,|\\s|\\})",
-          "name": "meta.record-entry.nushell",
-          "patterns": [{ "include": "#value" }]
+          "name": "meta.record-entry.nushell"
+        },
+        {
+          "match": "(\"(?:[^\"\\\\]|\\\\.)*\")\\s*(:)\\s*",
+          "captures": {
+            "1": { "name": "variable.other.nushell" },
+            "2": { "name": "keyword.control.nushell" }
+          },
+          "name": "meta.record-entry.nushell"
+        },
+        {
+          "match": "(\\$'([^']*)')\\s*(:)\\s*",
+          "captures": {
+            "1": { "name": "variable.other.nushell" },
+            "2": { "name": "variable.other.nushell", "patterns": [{ "include": "#paren-expression" }] },
+            "3": { "name": "keyword.control.nushell" }
+          },
+          "name": "meta.record-entry.nushell"
+        },
+        {
+          "match": "('[^']*')\\s*(:)\\s*",
+          "captures": {
+            "1": { "name": "variable.other.nushell" },
+            "2": { "name": "keyword.control.nushell" }
+          },
+          "name": "meta.record-entry.nushell"
         },
         { "include": "source.nushell" }
       ]

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -542,7 +542,7 @@
       ]
     },
     "define-variable": {
-      "match": "(let|mut|const)\\s+(\\w+)\\s*(=)",
+      "match": "(let|mut|(?:export\\s+)?const)\\s+(\\w+)\\s+(=)",
       "captures": {
         "1": { "name": "keyword.other.nushell" },
         "2": { "name": "variable.other.nushell" },

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -192,7 +192,7 @@
       "name": "keyword.control.nushell"
     },
     "operators-symbols": {
-      "match": "(?<= )(?:\\+|\\-|\\*|\\/|\\/\\/|\\*\\*|!=|[<>=]=?|[!=]~|&&|\\|\\||\\||\\+\\+=?)(?= |$)",
+      "match": "(?<= )(?:(?:\\+|\\-|\\*|\\/)=?|\\/\\/|\\*\\*|!=|[<>=]=?|[!=]~|\\+\\+=?)(?= |$)",
       "name": "keyword.control.nushell"
     },
     "operators": {
@@ -655,6 +655,10 @@
         { "include": "#pre-command" },
         { "include": "#for-loop" },
         { "include": "#operators" },
+        { 
+          "match": "\\|",
+          "name": "keyword.control.nushell"
+        },
         { "include": "#control-keywords" },
         { "include": "#constant-value" },
         { "include": "#command" },

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -542,7 +542,7 @@
       ]
     },
     "define-variable": {
-      "match": "(let(?:-env)?|mut|const)\\s+(\\w+)\\s*(=)",
+      "match": "(let|mut|const)\\s+(\\w+)\\s*(=)",
       "captures": {
         "1": { "name": "keyword.other.nushell" },
         "2": { "name": "variable.other.nushell" },

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -265,7 +265,7 @@
         },
         {
           "begin": "\\??:\\s*",
-          "end": "(?=(?:\\s+(?:-{0,2}|\\.{3})[\\w-]+)|(?:\\s*(?:,|\\]|@|=|#|$)))",
+          "end": "(?=(?:\\s+(?:-{0,2}|\\.{3})[\\w-]+)|(?:\\s*(?:,|\\]|\\||@|=|#|$)))",
           "patterns": [
             { "include": "#types" }
           ]
@@ -278,7 +278,7 @@
         {
           "name": "default.value.nushell",
           "begin": "=\\s*",
-          "end": "(?=(?:\\s+-{0,2}[\\w-]+)|(?:\\s*(?:,|\\]|#|$)))",
+          "end": "(?=(?:\\s+-{0,2}[\\w-]+)|(?:\\s*(?:,|\\]|\\||#|$)))",
           "patterns": [{ "include": "#value" }]
         }
       ]
@@ -504,20 +504,9 @@
       "patterns": [{ "include": "#expression" }]
     },
     "braced-expression": {
-      "begin": "(\\{)(?:\\s*\\|([\\w, ]*)\\|)?",
+      "begin": "\\{",
       "beginCaptures": {
-        "1": {
-          "name": "punctuation.section.block.begin.bracket.curly.nushell"
-        },
-        "2": {
-          "patterns": [
-            { "include": "#function-parameter" },
-            {
-              "match": ",",
-              "name": "punctuation.separator.nushell"
-            }
-          ]
-        }
+        "0": { "name": "punctuation.section.block.begin.bracket.curly.nushell" }
       },
       "end": "\\}",
       "endCaptures": {
@@ -525,6 +514,12 @@
       },
       "name": "meta.expression.braced.nushell",
       "patterns": [
+        {
+          "begin": "(?<=\\{)\\s*\\|",
+          "end": "\\|",
+          "name": "meta.closure.parameters.nushell",
+          "patterns": [{ "include": "#function-parameter" }]
+        },
         {
           "match": "(\\w+)\\s*(:)\\s*",
           "captures": {


### PR DESCRIPTION
* Improvement on closure parameters parsing (`{|...| }`)
* Improvement on record entries (fields name) parsing (`field:`)

![image](https://github.com/nushell/vscode-nushell-lang/assets/6421451/0fe63029-d3a4-4a4e-99e6-f285cfa6cd06)

**Known issue :**
There are issues in interpolated strings if there is a quote following by a colon.

![image](https://github.com/nushell/vscode-nushell-lang/assets/6421451/42ba3025-8232-4e8c-9fff-5bffdd4fb27a)

