### PR TITLE
Add spread to syntax highlighting

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -183,8 +183,12 @@
         { "include": "#binary" }
       ]
     },
+    "spread": {
+      "match": "\\.\\.\\.(?=\\S)",
+      "name": "keyword.control.nushell"
+    },
     "ranges": {
-      "match": "\\.\\.<?|:",
+      "match": "\\.\\.<?",
       "name": "keyword.control.nushell"
     },
     "operators-word": {
@@ -213,6 +217,7 @@
       },
       "name": "meta.table.nushell",
       "patterns": [
+        { "include": "#spread" },
         { "include": "#value" },
         {
           "match": ",",
@@ -223,7 +228,7 @@
     },
     "types": {
       "patterns": [
-        { 
+        {
           "name": "meta.list.nushell",
           "begin": "\\b(list)\\s*<",
           "beginCaptures": {
@@ -243,7 +248,7 @@
           "end": ">",
           "patterns": [
             {
-              "match": "([\\w\\-]+|\"[\\w\\- ]+\"|'[^']+')\\s*:\\s*", 
+              "match": "([\\w\\-]+|\"[\\w\\- ]+\"|'[^']+')\\s*:\\s*",
               "captures": {
                 "1": { "name": "variable.parameter.nushell" }
               }
@@ -251,7 +256,7 @@
             { "include": "#types" }
           ]
         },
-        { 
+        {
           "match": "\\b(\\w+)\\b",
           "name": "entity.name.type.nushell"
         }
@@ -561,6 +566,7 @@
           },
           "name": "meta.record-entry.nushell"
         },
+        { "include": "#spread" },
         { "include": "source.nushell" }
       ]
     },
@@ -650,7 +656,7 @@
         { "include": "#pre-command" },
         { "include": "#for-loop" },
         { "include": "#operators" },
-        { 
+        {
           "match": "\\|",
           "name": "keyword.control.nushell"
         },

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -217,6 +217,7 @@
       },
       "name": "meta.table.nushell",
       "patterns": [
+        { "include": "#spread" },
         { "include": "#value" },
         {
           "match": ",",
@@ -648,7 +649,7 @@
       },
       "end": "(?=\\||\\)|\\}|;)|$",
       "name": "meta.command.nushell",
-      "patterns": [{ "include": "#value" }]
+      "patterns": [{ "include": "#spread" }, { "include": "#value" }]
     },
     "expression": {
       "patterns": [
@@ -673,7 +674,6 @@
         { "include": "#constant-value" },
         { "include": "#table" },
         { "include": "#parameters" },
-        { "include": "#spread" },
         { "include": "#operators" },
         { "include": "#paren-expression" },
         { "include": "#braced-expression" },

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -184,7 +184,7 @@
       ]
     },
     "spread": {
-      "match": "\\.\\.\\.(?=\\S)",
+      "match": "\\.\\.\\.(?=[^\\s\\]}])",
       "name": "keyword.control.nushell"
     },
     "ranges": {

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -217,13 +217,11 @@
       },
       "name": "meta.table.nushell",
       "patterns": [
-        { "include": "#spread" },
         { "include": "#value" },
         {
           "match": ",",
           "name": "punctuation.separator.nushell"
-        },
-        { "include": "#comment" }
+        }
       ]
     },
     "types": {
@@ -285,7 +283,8 @@
           "begin": "=\\s*",
           "end": "(?=(?:\\s+-{0,2}[\\w-]+)|(?:\\s*(?:,|\\]|\\||#|$)))",
           "patterns": [{ "include": "#value" }]
-        }
+        },
+        { "include": "#spread" }
       ]
     },
     "function-parameters": {
@@ -674,6 +673,7 @@
         { "include": "#constant-value" },
         { "include": "#table" },
         { "include": "#parameters" },
+        { "include": "#spread" },
         { "include": "#operators" },
         { "include": "#paren-expression" },
         { "include": "#braced-expression" },

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -264,8 +264,11 @@
     "function-parameter": {
       "patterns": [
         {
-          "match": "((?:-{0,2}|\\.{3})[\\w-]+)(?:\\((-[\\w?])\\))?",
-          "name": "variable.parameter.nushell"
+          "match": "(?:-{0,2}|(\\.{3}))[\\w-]+(?:\\((-[\\w?])\\))?",
+          "name": "variable.parameter.nushell",
+          "captures": {
+            "1": { "name": "keyword.control.nushell" }
+          }
         },
         {
           "begin": "\\??:\\s*",
@@ -284,8 +287,7 @@
           "begin": "=\\s*",
           "end": "(?=(?:\\s+-{0,2}[\\w-]+)|(?:\\s*(?:,|\\]|\\||#|$)))",
           "patterns": [{ "include": "#value" }]
-        },
-        { "include": "#spread" }
+        }
       ]
     },
     "function-parameters": {

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -264,7 +264,7 @@
     "function-parameter": {
       "patterns": [
         {
-          "match": "(?:-{0,2}|(\\.{3}))[\\w-]+(?:\\((-[\\w?])\\))?",
+          "match": "(-{0,2}|\\.{3})[\\w-]+(?:\\((-[\\w?])\\))?",
           "name": "variable.parameter.nushell",
           "captures": {
             "1": { "name": "keyword.control.nushell" }
@@ -651,7 +651,19 @@
       },
       "end": "(?=\\||\\)|\\}|;)|$",
       "name": "meta.command.nushell",
-      "patterns": [{ "include": "#spread" }, { "include": "#value" }]
+      "patterns": [
+        {
+          "match": "(-{1,2})(.+)",
+          "captures": {
+            "1": { "name": "keyword.control.nushell" },
+            "2": {
+              "patterns": [{ "include": "#string-bare" }]
+            }
+          }
+        },
+        { "include": "#spread" },
+        { "include": "#value" }
+      ]
     },
     "expression": {
       "patterns": [

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -115,8 +115,11 @@
       "name": "keyword.other.nushell"
     },
     "parameters": {
-      "match": "\\b-{1,2}[\\w-]*",
-      "name": "variable.parameter.nushell"
+      "match": "(?<=\\s)(-{1,2})[\\w-]+",
+      "name": "variable.parameter.nushell",
+      "captures": {
+        "1": { "name": "keyword.control.nushell" }
+      }
     },
     "variables": {
       "match": "(\\$[a-zA-Z0-9_]+)((?:\\.(?:[\\w-]+|\"[\\w\\- ]+\"))*)",
@@ -652,15 +655,7 @@
       "end": "(?=\\||\\)|\\}|;)|$",
       "name": "meta.command.nushell",
       "patterns": [
-        {
-          "match": "(-{1,2})(.+)",
-          "captures": {
-            "1": { "name": "keyword.control.nushell" },
-            "2": {
-              "patterns": [{ "include": "#string-bare" }]
-            }
-          }
-        },
+        { "include": "#parameters" },
         { "include": "#spread" },
         { "include": "#value" }
       ]
@@ -687,7 +682,6 @@
         { "include": "#control-keywords" },
         { "include": "#constant-value" },
         { "include": "#table" },
-        { "include": "#parameters" },
         { "include": "#operators" },
         { "include": "#paren-expression" },
         { "include": "#braced-expression" },


### PR DESCRIPTION
Fixes #173.

Generated tokens for:

```nushell
def cmd [--flag (-f) ...rest] {
  [ ...$rest ]
  { ...$rest }
  all --flag -f ...$rest
}
cmd --flag -f ...$rest
^cmd --flag -f ...$rest
```

- `def cmd [`
  - `...`
    1. `keyword.control.nushell`
    2. `meta.function.parameters.nushell`
    3. `source.nushell`
  - `rest`
    1. `variable.parameter.nushell`
    2. `meta.function.parameters.nushell`
    3. `source.nushell`
- `] {`
  - `[`
    - `...`
      1. `keyword.control.nushell`
      2. `meta.table.nushell`
      3. `meta.function.body.nushell`
      4. `source.nushell`
    - `$rest`
      1. `variable.other.nushell`
      2. `meta.table.nushell`
      3. `meta.function.body.nushell`
      4. `source.nushell`
  - `]`
  - `{`
    - `...`
      1. `keyword.control.nushell`
      2. `meta.expression.braced.nushell`
      3. `meta.function.body.nushell`
      4. `source.nushell`
    - `$rest`
      1. `variable.other.nushell`
      2. `meta.expression.braced.nushell`
      3. `meta.function.body.nushell`
      4. `source.nushell`
  - `}`
  - `all` - `keyword.other.builtin.nushell`
    - `...`
      1. `keyword.control.nushell`
      2. `meta.command.nushell`
      3. `meta.function.body.nushell`
      4. `source.nushell`
    - `$rest`
      1. `variable.other.nushell`
      2. `meta.command.nushell`
      3. `meta.function.body.nushell`
      4. `source.nushell`
- `cmd` - `entity.name.type.external.nushell`
  - `...`
    1. `keyword.control.nushell`
    2. `meta.command.nushell`
    3. `source.nushell`
  - `$rest`
    1. `variable.other.nushell`
    2. `meta.command.nushell`
    3. `source.nushell`
- `^` - `keyword.operator.nushell`
  - `cmd ...$rest` - same as above
