### PR TITLE
:bug: fix markdown formatting for hover lsp

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -143,6 +143,9 @@ export function activate(context: vscode.ExtensionContext) {
       // Notify the server about file changes to '.clientrc files contained in the workspace
       fileEvents: vscode.workspace.createFileSystemWatcher("**/.clientrc"),
     },
+    markdown: {
+      isTrusted: true
+    }
   };
 
   // Create the language client and start the client.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -483,7 +483,7 @@ connection.onHover(async (request: HoverParams) => {
       // getting runtime import errors to remove this deprecation warning.
       const contents = {
         value: obj.hover,
-        language: "nushell",
+        kind: "markdown"
       };
 
       if (obj.hover != "") {


### PR DESCRIPTION
Hi, I wandered around for a bit and found out that when the server returns a hover, [you have to inform](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markupContentInnerDefinition) the client which type of `plaintext | markdown` [you are returning](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markupContent).

So, instead of
```typescript
      const contents = {
        value: obj.hover, // actual hover string
        language: "nushell",
      };
```
it should be
```typescript
      const contents = {
        value: obj.hover, // actual hover string
        kind: "markdown"
      };
```
(note that both key and value changed)

and you get the result 😄 
![image](https://github.com/nushell/vscode-nushell-lang/assets/30557287/79c40da9-11da-47ca-8aed-ed3b54b5b607)

By removing the `language: nushell` key, it defeats me how vscode knows that the code block (`\``) parts of the hover are in nushell syntax, because that is not written in the raw hover string 🧠 .

I hope this doesn't break any other editor that doesn't have markdown syntax!