### PR TITLE
Remove `/` and `\` from wordPattern

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -41,7 +41,7 @@
       "end": "^\\s*# endregion"
     }
   },
-  "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)",
+  "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\?\\s]+)",
   "indentationRules": {
     "increaseIndentPattern": "{{?(def|def-env|else|extern|for|if|let|let-env|with-env)\\b.*}}?",
     "decreaseIndentPattern": "{{?/(def|def-env|for|if)\\b}}?"


### PR DESCRIPTION
This removes `/` and `\` from the `wordPattern` value in the `language-configuration.json`, which fixes #185, allowing path completion to work properly.

https://code.visualstudio.com/api/language-extensions/language-configuration-guide#word-pattern
> `wordPattern` defines what's considered as a word in the programming language. Code suggestion features will use this setting to determine word boundaries if `wordPattern` is set.

I'm not entirely sure this is the best possible fix, but everything I tested seems to work the way I expected and I can auto-complete paths now. For example, I tried creating a variable with a slash in the name, but it still doesn't treat that as a valid variable name.

Two thoughts according to my limited understanding of how this works:
1. I see that the current value of `wordPattern` comes straight from the [official example](https://github.com/microsoft/vscode-extension-samples/blob/main/language-configuration-sample/language-configuration.json#L35). My best guess is that a typical language server doesn't implement path completion, so usually you wouldn't want directory separators included in your word pattern. Nushell's language server does appear to do path completion, though, so it seems to make sense to allow those characters when trying to auto-complete.
2. Most of the [built-in VSCode plugins](https://github.com/search?q=repo%3Amicrosoft%2Fvscode+path%3Alanguage-configuration.json&type=code) (including [shellscript](https://github.com/microsoft/vscode/tree/main/extensions/shellscript)) don't have a `wordPattern` defined, so maybe this field isn't even needed most of the time?