### PR TITLE
Feat: syntax highlighting in markdown code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This [extension for VSCode](https://marketplace.visualstudio.com/items?itemName=
 
 ## Features
 
-- Syntax highlighting grammar for Nushell scripts (`.nu` files)
+- Syntax highlighting grammar for Nushell scripts (`.nu` files) and ``nushell`` codeblocks in Markdown files
 - Goto definition
 - Hover support
 - Validation (errors with red squiggly lines)

--- a/package.json
+++ b/package.json
@@ -51,6 +51,16 @@
         "language": "nushell",
         "scopeName": "source.nushell",
         "path": "./syntaxes/nushell.tmLanguage.json"
+      },
+      {
+        "scopeName": "markdown.nushell.codeblock",
+        "path": "./syntaxes/codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.nushell": "nushell"
+        }
       }
     ],
     "keybindings": [

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#nushell-code-block"
+		}
+	],
+	"repository": {
+		"nushell-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(nushell)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.nushell",
+					"patterns": [
+						{
+							"include": "source.nushell"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.nushell.codeblock"
+}

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,45 +1,45 @@
 {
-	"fileTypes": [],
-	"injectionSelector": "L:text.html.markdown",
-	"patterns": [
-		{
-			"include": "#nushell-code-block"
-		}
-	],
-	"repository": {
-		"nushell-code-block": {
-			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(nushell)(\\s+[^`~]*)?$)",
-			"name": "markup.fenced_code.block.markdown",
-			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
-			"beginCaptures": {
-				"3": {
-					"name": "punctuation.definition.markdown"
-				},
-				"4": {
-					"name": "fenced_code.block.language.markdown"
-				},
-				"5": {
-					"name": "fenced_code.block.language.attributes.markdown"
-				}
-			},
-			"endCaptures": {
-				"3": {
-					"name": "punctuation.definition.markdown"
-				}
-			},
-			"patterns": [
-				{
-					"begin": "(^|\\G)(\\s*)(.*)",
-					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
-					"contentName": "meta.embedded.block.nushell",
-					"patterns": [
-						{
-							"include": "source.nushell"
-						}
-					]
-				}
-			]
-		}
-	},
-	"scopeName": "markdown.nushell.codeblock"
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#nushell-code-block"
+    }
+  ],
+  "repository": {
+    "nushell-code-block": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(nushell)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language.attributes.markdown"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.nushell",
+          "patterns": [
+            {
+              "include": "source.nushell"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.nushell.codeblock"
 }


### PR DESCRIPTION
### Feature: add syntax highlighting inside nushell codeblocks in markdown files

#### Issue #192

Adds syntax highlighting for nushell code blocks when editing markdown files inside VS code

The code is very inspired from [this repo](https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example).

⚠️ The syntax highlighting still is **not available** when opening the Preview of the md files in VS code. VS code uses something else (highlight.js) so that will be done and somewhere else I guess.

#### How to test

1. Clone the branch
2. Start debugging (F5) in VS Code
3. Open a md files, create a ``nushell`` code block and start typing nushell code

#### Result
<img width="850" alt="2025-03-10_23h17_14" src="https://github.com/user-attachments/assets/f84bda1f-334a-4214-ac8c-3a1dc1d719cb" />
