### PR TITLE
Support raw strings

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -24,7 +24,14 @@
     { "open": "'", "close": "'", "notIn": ["string", "comment"] },
     { "open": "\"", "close": "\"", "notIn": ["string"] },
     { "open": "`", "close": "`", "notIn": ["string", "comment"] },
-    { "open": "/**", "close": " */", "notIn": ["string"] }
+    { "open": "/**", "close": " */", "notIn": ["string"] },
+    { "open": "r#'", "close": "'#", "notIn": ["string"] },
+    { "open": "r##'", "close": "'##", "notIn": ["string"] },
+    { "open": "r###'", "close": "'###", "notIn": ["string"] },
+    { "open": "r####'", "close": "'####", "notIn": ["string"] },
+    { "open": "r#####'", "close": "'#####", "notIn": ["string"] },
+    { "open": "r######'", "close": "'######", "notIn": ["string"] }
+    // and so on...
   ],
   // symbols that can be used to surround a selection
   "surroundingPairs": [

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -20,7 +20,8 @@
         { "include": "#string-double-quote" },
         { "include": "#string-interpolated-double" },
         { "include": "#string-interpolated-single" },
-        { "include": "#string-bare" }
+        { "include": "#string-bare" },
+        { "include": "#string-raw" }
       ]
     },
     "string-escape": {
@@ -30,6 +31,17 @@
     "string-bare": {
       "match": "[^$\\[{(\"',|#\\s|][^\\[\\]{}()\"'\\s#,|]*",
       "name": "string.bare.nushell"
+    },
+    "string-raw": {
+      "begin": "(?<=r)(#+)'",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.nushell" }
+      },
+      "end": "'\\1",
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.nushell" }
+      },
+      "name": "string.raw.nushell"
     },
     "string-single-quote": {
       "begin": "'",


### PR DESCRIPTION
This pull request adds syntax highlighting for raw strings (#196) and autoClosingPairs.

## Implementation notes
- Since autoClosingPairs does not seem to support regex open/close, I have had to repeat a couple of possible raw string pairs. One could add more...
- The current highlight color chosen (for `r`, `#` and the string itself) is of course opinionated. I just choose that which I found easiest to implement.
- I have not added the condition `"notIn": ["comment"]`, because while typing a raw string, one enters a comment `r#`, and the `notIn` would therefore always fail. This could be changed however, depending on question 3. below.
## Questions
1. Some raw string examples should probably be included in `example.nu`, however that file is generated and so  I do not know how the example strings should be added.
2. Unrelated, but what is the autoClosingPair `/**` `*/` used for in the Nushell language?
3. Also unrelated, but I noticed that the syntax highlighting of e.g.
    ```nushell
    echo hello#there
    ```
    is also wrong. `#there` is not considered as a comment by Nushell, but rather as a part of (in this case) the bare string. For a comment to actually be a comment, I think that there must be either a new line or white-space before it, i.e. by replacing the current regex `"match": "(#.*)$"` with `"match": "(?<=^|\\s)(#.*)$"`.