### PR TITLE
Remove irrelevant autoClosingPair /**

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -24,7 +24,6 @@
     { "open": "'", "close": "'", "notIn": ["string", "comment"] },
     { "open": "\"", "close": "\"", "notIn": ["string"] },
     { "open": "`", "close": "`", "notIn": ["string", "comment"] },
-    { "open": "/**", "close": " */", "notIn": ["string"] },
     { "open": "r#'", "close": "'#", "notIn": ["string"] },
     { "open": "r##'", "close": "'##", "notIn": ["string"] },
     { "open": "r###'", "close": "'###", "notIn": ["string"] },


### PR DESCRIPTION
Removes the autoClosingPair `/**` `*/` which means nothing in particular to Nushell.