### PR TITLE
Improve highlighting of bare and raw strings, and add missing unit & operators

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -167,7 +167,7 @@
       "name": "constant.numeric.nushell"
     },
     "numbers": {
-      "match": "(?<![\\w-])[-+]?(?:\\d+|\\d{1,3}(?:_\\d{3})*)(?:\\.\\d*)?(?i:ns|us|ms|sec|min|hr|day|wk|b|kb|mb|gb|tb|pt|eb|zb|kib|mib|gib|tib|pit|eib|zib)?(?:(?![\\w.])|(?=\\.\\.))",
+      "match": "(?<![\\w-])[-+]?(?:\\d+|\\d{1,3}(?:_\\d{3})*)(?:\\.\\d*)?(?i:ns|us|µs|ms|sec|min|hr|day|wk|b|kb|mb|gb|tb|pt|eb|zb|kib|mib|gib|tib|pit|eib|zib)?(?:(?![\\w.])|(?=\\.\\.))",
       "name": "constant.numeric.nushell"
     },
     "binary": {
@@ -207,7 +207,7 @@
       "name": "keyword.control.nushell"
     },
     "operators-word": {
-      "match": "(?<= |\\()(?:mod|in|not-in|not|and|or|xor|bit-or|bit-and|bit-xor|bit-shl|bit-shr|starts-with|ends-with)(?= |\\)|$)",
+      "match": "(?<= |\\()(?:mod|in|not-in|not|and|or|xor|bit-or|bit-and|bit-xor|bit-shl|bit-shr|starts-with|ends-with|like|not-like)(?= |\\)|$)",
       "name": "keyword.control.nushell"
     },
     "operators-symbols": {

--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -20,8 +20,8 @@
         { "include": "#string-double-quote" },
         { "include": "#string-interpolated-double" },
         { "include": "#string-interpolated-single" },
-        { "include": "#string-bare" },
-        { "include": "#string-raw" }
+        { "include": "#string-raw" },
+        { "include": "#string-bare" }
       ]
     },
     "string-escape": {
@@ -29,11 +29,11 @@
       "name": "constant.character.escape.nushell"
     },
     "string-bare": {
-      "match": "[^$\\[{(\"',|#\\s|][^\\[\\]{}()\"'\\s#,|]*",
+      "match": "[^$\\[{(\"',|#\\s|;][^\\[\\]{}()\"'\\s,|;]*",
       "name": "string.bare.nushell"
     },
     "string-raw": {
-      "begin": "(?<=r)(#+)'",
+      "begin": "r(#+)'",
       "beginCaptures": {
         "0": { "name": "punctuation.definition.string.begin.nushell" }
       },
@@ -685,6 +685,7 @@
         },
         { "include": "#control-keywords" },
         { "include": "#constant-value" },
+        { "include": "#string-raw" },
         { "include": "#command" },
         { "include": "#value" }
       ]


### PR DESCRIPTION
- Added `µs` as a valid unit.
- Added the new operators `like` and `not-like`.
- Disallowed semicolon in bare strings (this should also fix #190)
- Allowed `#` in bare strings (except for the first character, since then it is a comment and not a bare string).
- Prioritized raw string highlighting over commands and bare strings (in e.g. `r'#str#'`, `r` should not be highlighted as a command).

### Sidenote
- Technically, commas should also be allowed in bare strings. However, commas can only be in some bare strings, since if the bare string is inside a list, then commas should not be recognized as part of the bare string: `[bare,strings]`). Hence, I have left commas disallowed as they were before.
- The new operators `like` and `not-like` are missing from the [Nushelll operators documentation](https://www.nushell.sh/book/operators.html) currently...
- Regarding a better regex for comments, I realized that the rules for when a comment is allowed without white-space in front of them is quite convoluted, so I have left it untouched.