### PR TITLE
Support floats, binary & octal literals (with underscores)

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -163,11 +163,19 @@
       "name": "constant.numeric.nushell"
     },
     "numbers-hexa": {
-      "match": "(?<![\\w-])0x[0-9a-fA-F]+(?![\\w.])",
+      "match": "(?<![\\w-])_*+0_*+x_*+[0-9a-fA-F][0-9a-fA-F_]*+(?![\\w.])",
+      "name": "constant.numeric.nushell"
+    },
+    "numbers-octal": {
+      "match": "(?<![\\w-])_*+0_*+o_*+[0-7][0-7_]*+(?![\\w.])",
+      "name": "constant.numeric.nushell"
+    },
+    "numbers-binary": {
+      "match": "(?<![\\w-])_*+0_*+b_*+[01][01_]*+(?![\\w.])",
       "name": "constant.numeric.nushell"
     },
     "numbers": {
-      "match": "(?<![\\w-])[-+]?(?:\\d+|\\d{1,3}(?:_\\d{3})*)(?:\\.\\d*)?(?i:ns|us|µs|ms|sec|min|hr|day|wk|b|kb|mb|gb|tb|pt|eb|zb|kib|mib|gib|tib|pit|eib|zib)?(?:(?![\\w.])|(?=\\.\\.))",
+      "match": "(?<![\\w-])_*+[-+]?_*+(?:(?i:NaN|infinity|inf)_*+|(?:\\d[\\d_]*+\\.?|\\._*+\\d)[\\d_]*+(?i:E_*+[-+]?_*+\\d[\\d_]*+)?)(?i:ns|us|µs|ms|sec|min|hr|day|wk|b|kb|mb|gb|tb|pt|eb|zb|kib|mib|gib|tib|pit|eib|zib)?(?:(?![\\w.])|(?=\\.\\.))",
       "name": "constant.numeric.nushell"
     },
     "binary": {
@@ -195,6 +203,8 @@
         { "include": "#datetime" },
         { "include": "#numbers" },
         { "include": "#numbers-hexa" },
+        { "include": "#numbers-octal" },
+        { "include": "#numbers-binary" },
         { "include": "#binary" }
       ]
     },


### PR DESCRIPTION
## Added
- Highlighting for numbers with exponential, e.g. `3E4` or `4e-1`.
- Highlighting for the numbers `infinity` and `NaN`.
- Octal and binary constants, e.g. `0b01` and `0o37`.
- Numbers with possibly absurd but valid usages of underscores. All of these are valid numbers in Nushell:
    ```nushell
    +___3.____
    ____NAN____
    _____.__4__
    ___-___Inf
    ___0__x___3___44___44____
    _+_____3___e___0___
   _00_0_._3___e___00__03__
    ```
    In other words, underscores can go anywhere in numeric literals. I have however not supported valid numbers such as ```_-_inf____in_ity```, since that would make the regex much less readable than it already is, and I think that anyone who uses that kind of constant does not deserve pretty syntax highlighting for it >:(.

## Notes
- I have used possessive quantifiers everywhere as to avoid potential catastrophic backtracking.