### PR TITLE
Add operators 'has' & 'has-not', and shorten operators-word regex

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -207,7 +207,7 @@
       "name": "keyword.control.nushell"
     },
     "operators-word": {
-      "match": "(?<= |\\()(?:mod|in|not-in|not|and|or|xor|bit-or|bit-and|bit-xor|bit-shl|bit-shr|starts-with|ends-with|like|not-like)(?= |\\)|$)",
+      "match": "(?<= |\\()(?:mod|in|not-(?:in|like|has)|not|and|or|xor|bit-(?:or|and|xor|shl|shr)|starts-with|ends-with|like|has)(?= |\\)|$)",
       "name": "keyword.control.nushell"
     },
     "operators-symbols": {


### PR DESCRIPTION
Aside from adding the two missing operators, I think the regex looks slightly better now by using extra groups to avoid repeating e.g. `not-`?

## Sidnote
- It might be better to automatically generate the list of binary operators, using the output of `help operators | select operator`, but meh.
- Another currently not highlighted operator is the (unary) [optional operator](https://www.nushell.sh/book/types_of_data.html#nothing-null) that can only be used on cell-paths. I might see if I can add it, but that will probably require improved syntax highlighting of various valid cell-paths.