### PR TITLE
add the ability to start and stop the lsp

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nushell-lsp-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nushell-lsp-client",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-nushell-lang",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-nushell-lang",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -38,7 +38,7 @@
     },
     "client": {
       "name": "nushell-lsp-client",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,17 @@
           "scope": "window"
         }
       }
-    }
+    },
+    "commands": [
+      {
+        "command": "nushell.stopLanguageServer",
+        "title": "Nushell: Stop Language Server"
+      },
+      {
+        "command": "nushell.startLanguageServer",
+        "title": "Nushell: Start Language Server"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run lint && npm run compile",


### PR DESCRIPTION
This PR adds the ability to start and stop the LSP. This is particularly helpful for when you have to make changes to the nushell rust code in Windows. Normally you'd have to quit out of vscode entirely since `nu --lsp` is running and windows does not allow you to overwrite a running executable. Now, we can simply do Ctrl-Shift-P and search for `Nushell: Stop Language Server` or `Nushell: Start Langauge Server`.

<img width="724" height="107" alt="image" src="https://github.com/user-attachments/assets/851fe182-a8df-41e0-a4fe-700523e07bde" />
