### PR TITLE
Better jsonrpc logging

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -6,6 +6,7 @@
 
 import * as vscode from 'vscode';
 import * as which from 'which';
+import { window, type OutputChannel } from 'vscode';
 
 import {
   LanguageClient,
@@ -15,6 +16,7 @@ import {
 import { time } from 'console';
 
 let client: LanguageClient;
+let outputChannel: OutputChannel;
 
 function findNushellExecutable(): string | null {
   try {
@@ -48,6 +50,8 @@ function startLanguageServer(
   context: vscode.ExtensionContext,
   found_nushell_path: string,
 ): void {
+  outputChannel = window.createOutputChannel('Nushell LSP Output', 'log');
+
   // Use Nushell's native LSP server
   const serverOptions: ServerOptions = {
     run: {
@@ -62,6 +66,11 @@ function startLanguageServer(
 
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
+    outputChannelName: 'Nushell Language Server',
+    markdown: {
+      isTrusted: true,
+      supportHtml: true,
+    },
     initializationOptions: {
       timeout: 10000, // 10 seconds
     },
@@ -167,6 +176,10 @@ export function activate(context: vscode.ExtensionContext) {
       });
     return;
   }
+
+  context.subscriptions.push(outputChannel);
+  console.log(`Found nushell executable at: ${found_nushell_path}`);
+  console.log('Activating Nushell Language Server extension.');
 
   // Start the language server when the extension is activated
   startLanguageServer(context, found_nushell_path);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-nushell-lang",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-nushell-lang",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "vscode-nushell-lang",
   "description": "nushell language for vscode",
   "author": "The Nushell Project Developers",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "preview": false,
   "license": "MIT",
   "publisher": "TheNuProjectContributors",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
             "messages",
             "verbose"
           ],
-          "default": "off",
+          "default": "messages",
           "description": "Traces the communication between VS Code and the language server."
         },
         "nushellLanguageServer.hints.showInferredTypes": {


### PR DESCRIPTION
This PR adds better JSONRPC logging so one can see the messages being sent to the LSP in order to debug the calls better. It also adds a new config option to change the verbosity of these messages.