### PR TITLE
don't auto-reveal output panel

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nushell-lsp-client",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nushell-lsp-client",
-      "version": "2.0.1",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "9.0.1",

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -12,6 +12,7 @@ import {
   LanguageClientOptions,
   ServerOptions,
   Trace,
+  RevealOutputChannelOn,
 } from 'vscode-languageclient/node';
 
 let client: LanguageClient;
@@ -90,6 +91,8 @@ function startLanguageServer(
   const clientOptions: LanguageClientOptions = {
     // Route general server logs to a single, reusable channel
     outputChannel: serverOutputChannel,
+    // Never auto-reveal the server output channel
+    revealOutputChannelOn: RevealOutputChannelOn.Never,
     // Send JSON-RPC trace to a dedicated channel visible in the Output panel
     traceOutputChannel: outputChannel,
     markdown: {
@@ -129,9 +132,6 @@ function startLanguageServer(
     client.setTrace(map[level]);
     try {
       outputChannel.appendLine(`[Nushell] JSON-RPC tracing set to: ${level}`);
-      if (level !== 'off') {
-        outputChannel.show(true);
-      }
     } catch {
       // ignore
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-nushell-lang",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-nushell-lang",
-      "version": "2.0.2",
+      "version": "2.0.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -38,7 +38,7 @@
     },
     "client": {
       "name": "nushell-lsp-client",
-      "version": "2.0.1",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "vscode-nushell-lang",
   "description": "nushell language for vscode",
   "author": "The Nushell Project Developers",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "preview": false,
   "license": "MIT",
   "publisher": "TheNuProjectContributors",


### PR DESCRIPTION
This PR removes the auto-reveal of the output panel when *.nu files are selected.

Thanks @cptpiepmatz!