### PR TITLE
update `def` syntax

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -375,11 +375,12 @@
       "patterns": [{ "include": "source.nushell" }]
     },
     "function": {
-      "begin": "((?:export\\s+)?def(?:\\s+--\\w+)*)\\s+([\\w\\-]+|\"[\\w\\- ]+\"|'[\\w\\- ]+'|`[\\w\\- ]+`)(\\s+--\\w+)*",
+      "begin": "((?:export\\s+)?def)(?:\\s+((?:--\\w+(?:\\s+--\\w+)*)))?\\s+([\\w\\-]+|\"[\\w\\- ]+\"|'[\\w\\- ]+'|`[\\w\\- ]+`)(?:\\s+((?:--\\w+(?:\\s+--\\w+)*)))?",
       "beginCaptures": {
         "1": { "name": "entity.name.function.nushell" },
-        "2": { "name": "entity.name.type.nushell" },
-        "3": { "name": "entity.name.function.nushell" }
+        "2": { "name": "entity.name.function.nushell" },
+        "3": { "name": "entity.name.type.nushell" },
+        "4": { "name": "entity.name.function.nushell" }
       },
       "end": "(?<=\\})",
       "patterns": [


### PR DESCRIPTION
This updates the `def` syntax so that it supports these:
- def bar [...args] {}
- def bar --wrapped --env [...args] {}
- def bar --env [...args] {}
- def bar --wrapped [...args] {}
- def --wrapped --env bar [...args] {}
- def --env bar [...args] {}
- def --wrapped bar [...args] {}
- def --wrapped bar --env [...args] {}

The lsp still doesn't like it but that's a different repo.

closes #221