### PR TITLE
fix: Syntax highlighting broken for record keys containing brackets

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -571,7 +571,7 @@
         {
           "match": "(\"(?:[^\"\\\\]|\\\\.)*\")\\s*(:)\\s*",
           "captures": {
-            "1": { "name": "variable.other.nushell" },
+            "1": { "name": "string.quoted.double.nushell variable.other.nushell" },
             "2": { "name": "keyword.control.nushell" }
           },
           "name": "meta.record-entry.nushell"
@@ -591,7 +591,7 @@
         {
           "match": "('[^']*')\\s*(:)\\s*",
           "captures": {
-            "1": { "name": "variable.other.nushell" },
+            "1": { "name": "string.quoted.single.nushell variable.other.nushell" },
             "2": { "name": "keyword.control.nushell" }
           },
           "name": "meta.record-entry.nushell"


### PR DESCRIPTION
## Issue

resolve #231

## Summary

This PR fixes an issue where brackets included in record keys were being treated as actual functional brackets, causing highlighting to break.
The scope for the entire key has been changed from a single `variable.other.nushell` to a compound scope prefixed with `string.quoted.*`.

## Changes

Updated the two rules for quoted keys within `repository.braced-expression` in `syntaxes/nushell.tmLanguage.json`:

```diff
-      "1": { "name": "variable.other.nushell" },
+      "1": { "name": "string.quoted.double.nushell variable.other.nushell" },
```

```diff
-      "1": { "name": "variable.other.nushell" },
+      "1": { "name": "string.quoted.single.nushell variable.other.nushell" },
```

## Background Information

- VS Code's bracket pair colorization only targets tokens whose standard token type, derived from the scope name, is `Other`.
	- https://github.com/microsoft/vscode/blob/42f75324c5ca687c5950d9b2fc661206a31eb0b6/src/vs/editor/common/model/bracketPairsTextModelPart/bracketPairsTree/tokenizer.ts#L203-L208
- By including `string` in the scope name, it is classified as a String type. Overlayering `string.quoted.*` ensures that brackets within the keys are excluded from bracket pair matching.
	- https://github.com/microsoft/vscode-textmate/blob/1701cf6b45b25bed3a07b44d059e0f7930be30f2/src/grammar/basicScopesAttributeProvider.ts#L54-L72
- Since `variable.other.nushell` is retained, key coloring in most themes will be preserved.

- In other language grammars, it is common for quoted keys to maintain a string scope:
  - JSON: `string.json support.type.property-name.json`
	  - https://github.com/microsoft/vscode/blob/42f75324c5ca687c5950d9b2fc661206a31eb0b6/extensions/json/syntaxes/JSON.tmLanguage.json#L171
  - TypeScript: `meta.object-literal.key.ts`
	  - https://github.com/microsoft/vscode/blob/42f75324c5ca687c5950d9b2fc661206a31eb0b6/extensions/typescript-basics/syntaxes/TypeScript.tmLanguage.json#L2755-L2766

## Verification

After applying these changes locally, I built the extension as a `.vsix` file and verified that the highlighting is rendered correctly when loaded.

<img width="302" height="264" alt="image" src="https://github.com/user-attachments/assets/9a2cc14a-6678-4e75-89ba-3e8218575418" />
