### PR TITLE
fix: Syntax highlighting broken for variable declarations with type annotations

### DIFF
--- a/syntaxes/nushell.tmLanguage.json
+++ b/syntaxes/nushell.tmLanguage.json
@@ -601,11 +601,15 @@
       ]
     },
     "define-variable": {
-      "match": "(let|mut|(?:export\\s+)?const)\\s+(\\w+)\\s+(=)",
+      "match": "(let|mut|(?:export\\s+)?const)\\s+(\\w+)(?:\\s*(:)\\s*([^=]+?))?\\s+(=)",
       "captures": {
         "1": { "name": "keyword.other.nushell" },
         "2": { "name": "variable.other.nushell" },
-        "3": {
+        "3": { "name": "punctuation.separator.nushell" },
+        "4": {
+          "patterns": [{ "include": "#types" }]
+        },
+        "5": {
           "patterns": [{ "include": "#operators" }]
         }
       }


### PR DESCRIPTION
## Issue

resolve #233

## Summary

This PR fixes an issue where adding a type annotation to a variable declaration (`let name: type = ...`) caused the variable name and the type to be highlighted as bare strings.
The `repository.define-variable` rule in `syntaxes/nushell.tmLanguage.json` now accepts an optional type annotation and delegates the type part to the existing `#types` repository.

## Background Information

- The previous `match` only covered declarations without a type annotation. When one was present, the rule failed to match and the line fell through to the `command` rule (`let`/`mut`/`const` are builtins), where `name:` and `type` were picked up by the `string-bare` fallback — hence the string color.
- The type part (capture 4) is delegated to the existing `#types` repository, the same way `#function-parameter` and `#function-inout` already handle type annotations. This keeps `list<...>`, `record<...>` etc. consistent between variable declarations and function signatures.
- The type capture `[^=]+?` is lazy and cannot cross the `=`, so right-hand sides containing `:` or `==` (e.g. `let flag: bool = 1 == 2`, `let f = {|x: int| $x}`) are not affected.
- The `:` (capture 3) is scoped as `punctuation.separator.nushell`, which this grammar already uses for the `,` separators in tables and in-out signatures.

## Verification

I verified the change by loading the extension in the VS Code Extension Development Host and confirming that typed declarations are now highlighted the same way as untyped ones and as type annotations in function signatures:

<img width="480" alt="Image" src="https://github.com/user-attachments/assets/4139e62b-da45-4d06-a292-c386a43f2837" />
